### PR TITLE
add support for inputType="numberDecimal"

### DIFF
--- a/library/src/main/java/com/afollestad/vvalidator/assertion/input/InputAssertions.kt
+++ b/library/src/main/java/com/afollestad/vvalidator/assertion/input/InputAssertions.kt
@@ -151,6 +151,70 @@ sealed class InputAssertions {
     }
   }
 
+  /** @author Chen Lei (@cooppor) */
+  class NumberDecimalAssertion internal constructor() : Assertion<EditText, NumberDecimalAssertion>() {
+    private var exactly: Double? = null
+    private var lessThan: Double? = null
+    private var atMost: Double? = null
+    private var atLeast: Double? = null
+    private var greaterThan: Double? = null
+
+    /** Asserts the number is an exact (=) value. */
+    fun exactly(length: Double): NumberDecimalAssertion {
+      exactly = length
+      return this
+    }
+
+    /** Asserts the number is less than (<) a value. */
+    fun lessThan(length: Double): NumberDecimalAssertion {
+      lessThan = length
+      return this
+    }
+
+    /** Asserts the number is at most (<=) a value. */
+    fun atMost(length: Double): NumberDecimalAssertion {
+      atMost = length
+      return this
+    }
+
+    /** Asserts the number is at least (>=) a value. */
+    fun atLeast(length: Double): NumberDecimalAssertion {
+      atLeast = length
+      return this
+    }
+
+    /** Asserts the number is greater (>) than a value. */
+    fun greaterThan(length: Double): NumberDecimalAssertion {
+      greaterThan = length
+      return this
+    }
+
+    override fun isValid(view: EditText): Boolean {
+      val doubleValue = view.text().toDoubleOrNull() ?: return false
+      if (exactly != null && doubleValue != exactly!!) return false
+      if (lessThan != null && doubleValue >= lessThan!!) return false
+      if (atMost != null && doubleValue > atMost!!) return false
+      if (atLeast != null && doubleValue < atLeast!!) return false
+      if (greaterThan != null && doubleValue <= greaterThan!!) return false
+      return true
+    }
+
+    override fun defaultDescription(): String {
+      val descriptionBuilder = StringBuilder().apply {
+        appendIf(exactly != null, "exactly $exactly")
+        appendIf(lessThan != null, "less than $lessThan")
+        appendIf(atMost != null, "at most $atMost")
+        appendIf(atLeast != null, "at least $atLeast")
+        appendIf(greaterThan != null, "greater than $greaterThan")
+      }
+      if (descriptionBuilder.isEmpty()) {
+        return "value must be a number"
+      }
+      return descriptionBuilder.insert(0, "value must be ")
+        .toString()
+    }
+  }
+
   /** @author Aidan Follestad (@afollestad) */
   class LengthAssertion internal constructor() : Assertion<EditText, LengthAssertion>() {
     private var exactly: Int? = null

--- a/library/src/main/java/com/afollestad/vvalidator/assertion/input/InputLayoutAssertions.kt
+++ b/library/src/main/java/com/afollestad/vvalidator/assertion/input/InputLayoutAssertions.kt
@@ -148,6 +148,66 @@ sealed class InputLayoutAssertions {
     }
   }
 
+  /** @author Chen Lei (@cooppor) */
+  class NumberDecimalAssertion internal constructor() : Assertion<TextInputLayout, NumberDecimalAssertion>() {
+    private var exactly: Double? = null
+    private var lessThan: Double? = null
+    private var atMost: Double? = null
+    private var atLeast: Double? = null
+    private var greaterThan: Double? = null
+
+    /** Asserts the number is an exact (=) value. */
+    fun exactly(length: Double): NumberDecimalAssertion {
+      exactly = length
+      return this
+    }
+
+    /** Asserts the number is less than (<) a value. */
+    fun lessThan(length: Double): NumberDecimalAssertion {
+      lessThan = length
+      return this
+    }
+
+    /** Asserts the number is at most (<=) a value. */
+    fun atMost(length: Double): NumberDecimalAssertion {
+      atMost = length
+      return this
+    }
+
+    /** Asserts the number is at least (>=) a value. */
+    fun atLeast(length: Double): NumberDecimalAssertion {
+      atLeast = length
+      return this
+    }
+
+    /** Asserts the number is greater (>) than a value. */
+    fun greaterThan(length: Double): NumberDecimalAssertion {
+      greaterThan = length
+      return this
+    }
+
+    override fun isValid(view: TextInputLayout): Boolean {
+      val intValue = view.text().toDoubleOrNull() ?: return false
+      return when {
+        exactly != null && intValue != exactly!! -> false
+        lessThan != null && intValue >= lessThan!! -> false
+        atMost != null && intValue > atMost!! -> false
+        atLeast != null && intValue < atLeast!! -> false
+        greaterThan != null && intValue <= greaterThan!! -> false
+        else -> true
+      }
+    }
+
+    override fun defaultDescription() = when {
+      exactly != null -> "must equal $exactly"
+      lessThan != null -> "must be less than $lessThan"
+      atMost != null -> "must be at most $atMost"
+      atLeast != null -> "must be at least $atLeast"
+      greaterThan != null -> "must be greater than $greaterThan"
+      else -> "must be a number"
+    }
+  }
+
   /** @author Aidan Follestad (@afollestad) */
   class LengthAssertion internal constructor() : Assertion<TextInputLayout, LengthAssertion>() {
     private var exactly: Int? = null

--- a/library/src/main/java/com/afollestad/vvalidator/field/input/InputField.kt
+++ b/library/src/main/java/com/afollestad/vvalidator/field/input/InputField.kt
@@ -25,6 +25,7 @@ import com.afollestad.vvalidator.assertion.input.InputAssertions.EmailAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.LengthAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.NotEmptyAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.NumberAssertion
+import com.afollestad.vvalidator.assertion.input.InputAssertions.NumberDecimalAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.RegexAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.UriAssertion
 import com.afollestad.vvalidator.field.FieldValue
@@ -75,6 +76,9 @@ open class InputField internal constructor(
 
   /** Asserts that the input text is a valid number. */
   fun isNumber() = assert(NumberAssertion())
+
+  /** Asserts that the input text is a valid decimal. */
+  fun isDecimal() = assert(NumberDecimalAssertion())
 
   /** Asserts on the input text length. */
   fun length() = assert(LengthAssertion())

--- a/library/src/main/java/com/afollestad/vvalidator/field/input/InputLayoutField.kt
+++ b/library/src/main/java/com/afollestad/vvalidator/field/input/InputLayoutField.kt
@@ -24,6 +24,7 @@ import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.EmailAsse
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.LengthAssertion
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.NotEmptyAssertion
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.NumberAssertion
+import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.NumberDecimalAssertion
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.RegexAssertion
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.UriAssertion
 import com.afollestad.vvalidator.assertion.input.text
@@ -82,6 +83,9 @@ class InputLayoutField internal constructor(
 
   /** Asserts that the input text is a valid number. */
   fun isNumber() = assert(NumberAssertion())
+
+  /** Asserts that the input text is a valid number. */
+  fun isDecimal() = assert(NumberDecimalAssertion())
 
   /** Asserts that the input text contains a string. */
   fun length() = assert(LengthAssertion())

--- a/library/src/test/java/com/afollestad/vvalidator/assertion/input/InputAssertionsTest.kt
+++ b/library/src/test/java/com/afollestad/vvalidator/assertion/input/InputAssertionsTest.kt
@@ -25,6 +25,7 @@ import com.afollestad.vvalidator.assertion.input.InputAssertions.EmailAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.LengthAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.NotEmptyAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.NumberAssertion
+import com.afollestad.vvalidator.assertion.input.InputAssertions.NumberDecimalAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.RegexAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.UriAssertion
 import com.afollestad.vvalidator.testutil.NoManifestTestRunner
@@ -210,6 +211,112 @@ class InputAssertionsTest {
         .assertFalse()
     assertion.defaultDescription()
         .assertEqualTo("value must be greater than 5")
+  }
+
+  @Test fun isDecimal() {
+    val assertion = NumberDecimalAssertion()
+
+    view.text = "1.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    view.text = "a".toEditable()
+    assertion.isValid(view)
+        .assertFalse()
+    assertion.defaultDescription()
+        .assertEqualTo("value must be a number")
+  }
+
+  @Test fun isDecimal_exactly() {
+    val assertion = NumberDecimalAssertion().apply {
+        exactly(5.0)
+    }
+
+    view.text = "5.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    view.text = "1.0".toEditable()
+    assertion.isValid(view)
+        .assertFalse()
+    assertion.defaultDescription()
+        .assertEqualTo("value must be exactly 5.0")
+  }
+
+  @Test fun isDecimal_lessThan() {
+    val assertion = NumberDecimalAssertion().apply {
+        lessThan(5.0)
+    }
+
+    view.text = "4.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    view.text = "5.0".toEditable()
+    assertion.isValid(view)
+        .assertFalse()
+    assertion.defaultDescription()
+        .assertEqualTo("value must be less than 5.0")
+  }
+
+  @Test fun isDecimal_atMost() {
+    val assertion = NumberDecimalAssertion().apply {
+        atMost(5.0)
+    }
+
+    view.text = "4.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    view.text = "5.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    view.text = "6.0".toEditable()
+    assertion.isValid(view)
+        .assertFalse()
+    assertion.defaultDescription()
+        .assertEqualTo("value must be at most 5.0")
+  }
+
+  @Test fun isDecimal_atLeast() {
+    val assertion = NumberDecimalAssertion().apply {
+        atLeast(5.0)
+    }
+
+    view.text = "5.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    view.text = "6.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    view.text = "4.0".toEditable()
+    assertion.isValid(view)
+        .assertFalse()
+    assertion.defaultDescription()
+        .assertEqualTo("value must be at least 5.0")
+}
+
+  @Test fun isDecimal_greaterThan() {
+    val assertion = NumberDecimalAssertion().apply {
+      greaterThan(5.0)
+    }
+
+    view.text = "6.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    view.text = "7.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    view.text = "5.0".toEditable()
+    assertion.isValid(view)
+        .assertFalse()
+    assertion.defaultDescription()
+        .assertEqualTo("value must be greater than 5.0")
   }
 
   @Test fun length() {

--- a/library/src/test/java/com/afollestad/vvalidator/assertion/input/InputLayoutAssertionsTest.kt
+++ b/library/src/test/java/com/afollestad/vvalidator/assertion/input/InputLayoutAssertionsTest.kt
@@ -26,6 +26,7 @@ import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.EmailAsse
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.LengthAssertion
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.NotEmptyAssertion
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.NumberAssertion
+import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.NumberDecimalAssertion
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.RegexAssertion
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.UriAssertion
 import com.afollestad.vvalidator.testutil.NoManifestTestRunner
@@ -218,6 +219,112 @@ class InputLayoutAssertionsTest {
         .assertFalse()
     assertion.defaultDescription()
         .assertEqualTo("must be greater than 5")
+  }
+
+  @Test fun isDecimal() {
+    val assertion = NumberDecimalAssertion()
+
+    editText.text = "1.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    editText.text = "a".toEditable()
+    assertion.isValid(view)
+        .assertFalse()
+    assertion.defaultDescription()
+        .assertEqualTo("must be a number")
+  }
+
+  @Test fun isDecimal_exactly() {
+    val assertion = NumberDecimalAssertion().apply {
+        exactly(5.0)
+    }
+
+    editText.text = "5.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    editText.text = "1.0".toEditable()
+    assertion.isValid(view)
+        .assertFalse()
+    assertion.defaultDescription()
+        .assertEqualTo("must equal 5.0")
+  }
+
+  @Test fun isDecimal_lessThan() {
+    val assertion = NumberDecimalAssertion().apply {
+        lessThan(5.0)
+    }
+
+    editText.text = "4.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    editText.text = "5.0".toEditable()
+    assertion.isValid(view)
+        .assertFalse()
+    assertion.defaultDescription()
+        .assertEqualTo("must be less than 5.0")
+  }
+
+  @Test fun isDecimal_atMost() {
+    val assertion = NumberDecimalAssertion().apply {
+        atMost(5.0)
+    }
+
+    editText.text = "4.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    editText.text = "5.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    editText.text = "6.0".toEditable()
+    assertion.isValid(view)
+        .assertFalse()
+    assertion.defaultDescription()
+        .assertEqualTo("must be at most 5.0")
+  }
+
+  @Test fun isDecimal_atLeast() {
+val assertion = NumberDecimalAssertion().apply {
+        atLeast(5.0)
+    }
+
+    editText.text = "5.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    editText.text = "6.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    editText.text = "4.0".toEditable()
+    assertion.isValid(view)
+        .assertFalse()
+    assertion.defaultDescription()
+        .assertEqualTo("must be at least 5.0")
+  }
+
+  @Test fun isDecimal_greaterThan() {
+    val assertion = NumberDecimalAssertion().apply {
+        greaterThan(5.0)
+    }
+
+    editText.text = "6.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    editText.text = "7.0".toEditable()
+    assertion.isValid(view)
+        .assertTrue()
+
+    editText.text = "5.0".toEditable()
+    assertion.isValid(view)
+        .assertFalse()
+    assertion.defaultDescription()
+        .assertEqualTo("must be greater than 5.0")
   }
 
   @Test fun length() {

--- a/library/src/test/java/com/afollestad/vvalidator/field/input/InputFieldTest.kt
+++ b/library/src/test/java/com/afollestad/vvalidator/field/input/InputFieldTest.kt
@@ -22,6 +22,7 @@ import com.afollestad.vvalidator.assertion.input.InputAssertions.EmailAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.LengthAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.NotEmptyAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.NumberAssertion
+import com.afollestad.vvalidator.assertion.input.InputAssertions.NumberDecimalAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.RegexAssertion
 import com.afollestad.vvalidator.assertion.input.InputAssertions.UriAssertion
 import com.afollestad.vvalidator.field.FieldError
@@ -131,6 +132,15 @@ class InputFieldTest {
   @Test fun isNumber() {
     val assertion = field.isNumber()
         .assertType<NumberAssertion>()
+    field.assertions()
+        .single()
+        .assertEqualTo(assertion)
+    assertion.conditions.assertEmpty()
+  }
+
+  @Test fun isDecimal() {
+    val assertion = field.isDecimal()
+        .assertType<NumberDecimalAssertion>()
     field.assertions()
         .single()
         .assertEqualTo(assertion)

--- a/library/src/test/java/com/afollestad/vvalidator/field/input/InputLayoutFieldTest.kt
+++ b/library/src/test/java/com/afollestad/vvalidator/field/input/InputLayoutFieldTest.kt
@@ -21,6 +21,7 @@ import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.EmailAsse
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.LengthAssertion
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.NotEmptyAssertion
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.NumberAssertion
+import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.NumberDecimalAssertion
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.RegexAssertion
 import com.afollestad.vvalidator.assertion.input.InputLayoutAssertions.UriAssertion
 import com.afollestad.vvalidator.field.FieldError
@@ -132,6 +133,15 @@ class InputLayoutFieldTest {
   @Test fun isNumber() {
     val assertion = field.isNumber()
         .assertType<NumberAssertion>()
+    field.assertions()
+        .single()
+        .assertEqualTo(assertion)
+    assertion.conditions.assertEmpty()
+  }
+
+  @Test fun isDecimal() {
+    val assertion = field.isDecimal()
+        .assertType<NumberDecimalAssertion>()
     field.assertions()
         .single()
         .assertEqualTo(assertion)

--- a/sample/src/main/java/com/afollestad/vvalidatorsample/MainActivity.kt
+++ b/sample/src/main/java/com/afollestad/vvalidatorsample/MainActivity.kt
@@ -66,6 +66,11 @@ class MainActivity : AppCompatActivity() {
         isNumber()
       }
 
+      input(R.id.input_weight, name = "Weight") {
+        isNotEmpty()
+        isDecimal().atMost(9999.99)
+      }
+
       spinner(R.id.input_spinner, name = "Have a website") {
         selection()
             .atLeast(1)

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -61,6 +61,19 @@
         style="@style/Form.InputField"
         />
 
+    <!-- Weight -->
+    <TextView
+        android:text="Weight"
+        style="@style/Form.Label"
+        />
+
+    <EditText
+        android:id="@+id/input_weight"
+        android:hint="Your weight"
+        android:inputType="numberDecimal"
+        style="@style/Form.InputField"
+        />
+
     <!-- Spinner -->
     <Spinner
         android:id="@+id/input_spinner"


### PR DESCRIPTION
Two reasons:
1. The original number type has a problem. When you enter the decimal type, the size judgment will be invalid, as shown in Figure 1.

numberDecimal 
```
    <!-- Weight -->
    <TextView
        android:text="Weight"
        style="@style/Form.Label"
        />

    <EditText
        android:id="@+id/input_weight"
        android:hint="Your weight"
        android:inputType="numberDecimal"
        style="@style/Form.InputField"
        />
```
using the isNumber()
```
input(R.id.input_weight, name = "Weight") {
        isNotEmpty()
        //isDecimal().atMost(9999.99)
        isNumber().atMost(999).description("This is the problem.")
}
```
![number_issue](https://user-images.githubusercontent.com/12547744/60026495-3ea5e680-96ce-11e9-966b-ac97a7af3117.gif)


2. Add support for the numberDecimal type, it will be convenient to use, and does not intrude into the original number type. In addition, considering the value range, the Double type is used here.

I hope to adopt, thank you.