### PR TITLE
Fixes ClassCastException on checkBoxError of sample project

### DIFF
--- a/sample/src/main/java/com/afollestad/vvalidatorsample/MainActivity.kt
+++ b/sample/src/main/java/com/afollestad/vvalidatorsample/MainActivity.kt
@@ -28,7 +28,7 @@ import com.afollestad.vvalidator.util.showOrHide
 
 /** @author Aidan Follestad (@afollestad) */
 class MainActivity : AppCompatActivity() {
-  private val checkBoxError by lazy { findViewById<CheckBox>(R.id.error_checkBox) }
+  private val checkBoxError by lazy { findViewById<TextView>(R.id.error_checkBox) }
   private val seekBarError by lazy { findViewById<TextView>(R.id.error_seekBar) }
   private val spinnerError by lazy { findViewById<TextView>(R.id.error_spinner) }
   private val inputSite by lazy { findViewById<EditText>(R.id.input_site) }


### PR DESCRIPTION
`checkBoxError` on MainActivity of sample project should be a TextView instead of Checkbox or else the app will crash with `ClassCastException`